### PR TITLE
Add notes on parameters to determine

### DIFF
--- a/parameters.md
+++ b/parameters.md
@@ -1,0 +1,26 @@
+Equation 10 of Jacobs, Jongen, and Zoutman (*Journal of Public Economics*, 2017) summarizes the equation to determine the social welfare weights.  The social welfare weight on a taxpayer with income $z$ is:
+
+$$
+g_z = 1 + \theta_z \varepsilon^c \frac{T'(z)}{(1-T'(z))} + \varepsilon^c \frac{zT''(z)}{(1-T'(z))^2}
+$$
+
+The parameters/functions that are necessary for computing these social welfare weights are summarized below:
+
+| Parameter/Function | Description | Source |
+| ------------------ | ----------- | ------ |
+| $\varepsilon^c$      | Compensated elasticity of taxable income       |  Economics literature |
+| $\theta_z$   | Elasticity of local tax base w.r.t. income $z$, $\theta_{z}\equiv 1 + \frac{zf'(z)}{f(z)}$        |  See JJZ (2017), will need Tax-Calculator + estimates from economics literature |
+| $T'(z)$ | Marginal tax rate for each taxpayer | Tax-Calculator |
+| $T''(z)$ | Derivative of the MTR for each taxpayer | Tax-Calculator (but will need to write a new function) |
+| $z$ | Pre-tax earnings of each taxpayer | Tax-Calculator/TaxData |
+| $f(z)$ | pdf of the distribution of earnings | Tax-Calculator/TaxData |
+| $f'(z)$ | derivative of the pdf of earnings | Tax-Calculator/TaxData |
+
+
+Some notes:
+* To start, maybe take a "sufficient statistics" approach
+  * Keep elasticities, the income distribution, and employment constant (JJZ (2017), pg. 86)
+  * Otherwise, may need a lot more structure on the model  (see Hendren (2014) and Lockwood (2016)?)
+  * Do we need to smooth out MTRs?
+    * Maybe just some average effective rate for each point in the income distribution
+


### PR DESCRIPTION
This PR adds a short document summarizing the necessary parameters for determining the social welfare weights.  These come from Equation 10 of Jacobs, Jongen, and Zoutman (*Journal of Public Economics*, 2017) (and follow their notation).