### PR TITLE
set main branch for deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Jupyter Book documentation
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-and-deploy:
     if: github.repository == 'PSLmodels/InverseOptimalTax'


### PR DESCRIPTION
This PR updates the GH action for the deployment of documentation to reference the `main` branch.