### PR TITLE
Update plots

### DIFF
--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -44,7 +44,7 @@ class IOT:
         upper_bound=500000,
         dist_type="kde_full",
         kde_bw=None,
-        mtr_smoother="cubic_spline",
+        mtr_smoother="spline",
     ):
 
         # keep the original data intact
@@ -116,7 +116,7 @@ class IOT:
             .groupby(["z_bin"])
             .apply(lambda x: np.average(x["mtr"], weights=x[weight_var]))
         )
-        if mtr_smoother == "cubic_spline":
+        if mtr_smoother == "spline":
             spl = UnivariateSpline(self.z, data_group.values, k=4)
             mtr = spl(self.z)
         elif mtr_smoother == "kr":

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -93,7 +93,9 @@ class IOT:
         df = pd.DataFrame.from_dict(dict_out)
         return df
 
-    def compute_mtr_dist(self, data, weight_var, mtr_smoother, mtr_smooth_param):
+    def compute_mtr_dist(
+        self, data, weight_var, mtr_smoother, mtr_smooth_param
+    ):
         """
         Compute marginal tax rates over the income distribution and
         their derivative.
@@ -118,13 +120,20 @@ class IOT:
             .apply(lambda x: np.average(x["mtr"], weights=x[weight_var]))
         )
         if mtr_smoother == "spline":
-            spl = UnivariateSpline(self.z, data_group.values, k=mtr_smooth_param)
+            spl = UnivariateSpline(
+                self.z, data_group.values, k=mtr_smooth_param
+            )
             mtr = spl(self.z)
         elif mtr_smoother == "kr":
             mtr_function = KernelReg(
-                data_group.values, self.z, var_type='c', reg_type='ll',
-                bw=[mtr_smooth_param], ckertype='gaussian',
-                defaults=None)
+                data_group.values,
+                self.z,
+                var_type="c",
+                reg_type="ll",
+                bw=[mtr_smooth_param],
+                ckertype="gaussian",
+                defaults=None,
+            )
             mtr, _ = mtr_function.fit(self.z)
         else:
             mtr = data_group.values

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -107,7 +107,7 @@ class iot_comparison:
                     dist_type=dist_type,
                     kde_bw=kde_bw,
                     mtr_smoother=mtr_smoother,
-                    mtr_smooth_param=mtr_smooth_param
+                    mtr_smooth_param=mtr_smooth_param,
                 )
             )
 
@@ -222,25 +222,33 @@ class iot_comparison:
             }
         )
         fig = go.Figure()
-        fig.add_trace(go.Scatter(
-            x=plot_df[self.income_measure],
-            y=plot_df["Overall weight"],
-            fill=None,
-            mode='lines',
-            name='Overall weight'
-            ))
-        fig.add_trace(go.Scatter(
-            x=plot_df[self.income_measure],
-            y=plot_df["Tax Base Elasticity"],
-            fill='tonexty',  # fill area between trace0 and trace1
-            mode='lines',
-            name='Tax Base Elasticity'))
-        fig.add_trace(go.Scatter(
-            x=plot_df[self.income_measure],
-            y=plot_df["Nonconstant MTRs"],
-            fill='tonexty',  # fill area between trace1 and trace2
-            mode='lines',
-            name='Nonconstant MTRs'))
+        fig.add_trace(
+            go.Scatter(
+                x=plot_df[self.income_measure],
+                y=plot_df["Overall weight"],
+                fill=None,
+                mode="lines",
+                name="Overall weight",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=plot_df[self.income_measure],
+                y=plot_df["Tax Base Elasticity"],
+                fill="tonexty",  # fill area between trace0 and trace1
+                mode="lines",
+                name="Tax Base Elasticity",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=plot_df[self.income_measure],
+                y=plot_df["Nonconstant MTRs"],
+                fill="tonexty",  # fill area between trace1 and trace2
+                mode="lines",
+                name="Nonconstant MTRs",
+            )
+        )
         fig.update_layout(
             xaxis_title=OUTPUT_LABELS[self.income_measure],
             yaxis_title=r"$g_z$",

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -265,8 +265,8 @@ class iot_comparison:
             {
                 self.income_measure: df.z,
                 "Overall weight": df.g_z,
-                "Tax Base Elasticity": df.g_z - g2,
-                "Nonconstant MTRs": df.g_z - g2 - g1,
+                "Tax Base Elasticity": df.g_z - g1,
+                "Nonconstant MTRs": df.g_z - g1 - g2,
             }
         )
         fig = go.Figure()

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -58,7 +58,7 @@ class iot_comparison:
         upper_bound=500000,
         dist_type="kde_full",
         kde_bw=None,
-        mtr_smoother="cubic_spline",
+        mtr_smoother="spline",
     ):
         self.income_measure = income_measure
         self.weight_var = weight_var

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -59,6 +59,7 @@ class iot_comparison:
         dist_type="kde_full",
         kde_bw=None,
         mtr_smoother="spline",
+        mtr_smooth_param=4,
     ):
         self.income_measure = income_measure
         self.weight_var = weight_var
@@ -106,6 +107,7 @@ class iot_comparison:
                     dist_type=dist_type,
                     kde_bw=kde_bw,
                     mtr_smoother=mtr_smoother,
+                    mtr_smooth_param=mtr_smooth_param
                 )
             )
 
@@ -194,56 +196,6 @@ class iot_comparison:
         return fig
 
     def JJZFig4(self, policy="Current Law"):
-        k = self.labels.index(policy)
-        df = self.iot[k].df()
-        # g1 with mtr_prime = 0
-        # g1 = 1 + (df.theta_z * self.iot[k].inc_elast * df.mtr) / (1 - df.mtr)
-        g1 = (
-            0.
-            + ((df.theta_z * self.iot[k].inc_elast * df.mtr) / (1 - df.mtr))
-            + ((self.iot[k].inc_elast * df.z * 0) / (1 - df.mtr) ** 2)
-        )
-        # g2 with theta_z = 0
-        # g2 = 1 + (
-        #     (self.iot[k].inc_elast * df.z * df.mtr_prime) / (1 - df.mtr) ** 2
-        # )
-        g2 = (
-            0.
-            + ((0 * self.iot[k].inc_elast * df.mtr) / (1 - df.mtr))
-            + (
-                (self.iot[k].inc_elast * df.z * df.mtr_prime)
-                / (1 - df.mtr) ** 2
-            )
-        )
-        plot_df = pd.DataFrame(
-            {
-                self.income_measure: df.z,
-                "Overall weight": df.g_z,
-                "Tax Base Elasticity": g1,
-                "Nonconstant MTRs": g2,
-                "": np.ones_like(g2)
-            }
-        )
-        fig = px.area(
-            plot_df,
-            x=plot_df[self.income_measure],
-            y=["", "Tax Base Elasticity", "Nonconstant MTRs"],
-        )
-        # fig.add_trace(px.line(plot_df, x=plot_df[self.income_measure], y='Overall weight'))
-        fig.add_trace(
-            go.Scatter(
-                x=plot_df[self.income_measure],
-                y=plot_df["Overall weight"],
-                name="Overall weight"
-            )
-        )
-        fig.update_layout(
-            xaxis_title=OUTPUT_LABELS[self.income_measure],
-            yaxis_title=r"$g_z$",
-        )
-        return fig
-
-    def JJZFig4_v2(self, policy="Current Law"):
         k = self.labels.index(policy)
         df = self.iot[k].df()
         # g1 with mtr_prime = 0

--- a/iot/tests/test_inverse_optimal_tax.py
+++ b/iot/tests/test_inverse_optimal_tax.py
@@ -25,7 +25,7 @@ def test_IOT_df():
     )
     data["mtr"] = mtr1
     # create instance of IOT object
-    iot1 = IOT(data, dist_type="log_normal", mtr_smoother="cubic_spline")
+    iot1 = IOT(data, dist_type="log_normal", mtr_smoother="cubic_spline", mtr_smooth_param=3)
     # return df from IOT object
     df_out = iot1.df()
 
@@ -65,7 +65,7 @@ def test_IOT_compute_mtr_dist():
     weight_var = "s006"
     # iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother)
     iot1 = IOT(data)
-    mtr, mtr_prime = iot1.compute_mtr_dist(data, weight_var, mtr_smoother)
+    mtr, mtr_prime = iot1.compute_mtr_dist(data, weight_var, mtr_smoother, 3)
     # np.savetxt(os.path.join(CUR_PATH, 'test_io_data', 'mtr.csv'), mtr, delimiter=",")
     expected_mtr = np.genfromtxt(
         os.path.join(CUR_PATH, "test_io_data", "mtr.csv"), delimiter=","
@@ -97,7 +97,7 @@ df["mtr"] = mtr1
 # create instance of IOT object
 mtr_smoother = "cubic_spline"
 weight_var = "s006"
-iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother)
+iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother,  mtr_smooth_param=3)
 iot2 = copy.deepcopy(iot1)
 iot2.theta_z = np.array([1.7, 2.4, 99.0, 1.5, 1.5, 1.5])
 iot2.inc_elast = np.array([0.3, 0.1, 0.0, 0.4, 0.4, 0.4])

--- a/iot/tests/test_inverse_optimal_tax.py
+++ b/iot/tests/test_inverse_optimal_tax.py
@@ -61,7 +61,7 @@ def test_IOT_compute_mtr_dist():
     )
     data["z_bin"] = pd.cut(data[income_measure], bins, include_lowest=True)
     # create instance of IOT object
-    mtr_smoother = "cubic_spline"
+    mtr_smoother = "spline"
     weight_var = "s006"
     # iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother)
     iot1 = IOT(data)
@@ -95,7 +95,7 @@ df = calc.dataframe(["s006", "expanded_income", "XTOT", "combined"])
 )
 df["mtr"] = mtr1
 # create instance of IOT object
-mtr_smoother = "cubic_spline"
+mtr_smoother = "spline"
 weight_var = "s006"
 iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother,  mtr_smooth_param=3)
 iot2 = copy.deepcopy(iot1)

--- a/iot/tests/test_inverse_optimal_tax.py
+++ b/iot/tests/test_inverse_optimal_tax.py
@@ -25,7 +25,12 @@ def test_IOT_df():
     )
     data["mtr"] = mtr1
     # create instance of IOT object
-    iot1 = IOT(data, dist_type="log_normal", mtr_smoother="cubic_spline", mtr_smooth_param=3)
+    iot1 = IOT(
+        data,
+        dist_type="log_normal",
+        mtr_smoother="cubic_spline",
+        mtr_smooth_param=3,
+    )
     # return df from IOT object
     df_out = iot1.df()
 
@@ -97,7 +102,9 @@ df["mtr"] = mtr1
 # create instance of IOT object
 mtr_smoother = "spline"
 weight_var = "s006"
-iot1 = IOT(df, dist_type="log_normal", mtr_smoother=mtr_smoother,  mtr_smooth_param=3)
+iot1 = IOT(
+    df, dist_type="log_normal", mtr_smoother=mtr_smoother, mtr_smooth_param=3
+)
 iot2 = copy.deepcopy(iot1)
 iot2.theta_z = np.array([1.7, 2.4, 99.0, 1.5, 1.5, 1.5])
 iot2.inc_elast = np.array([0.3, 0.1, 0.0, 0.4, 0.4, 0.4])


### PR DESCRIPTION
This PR updates the JJZ (2017) Fig 4 plot and the Saez (2001) Fig 2 plots.

In addition, I've found that a quartic spline does a much better job smoothing marginal tax rates than a cubic spline, which misses key variations in the marginal tax rate schedule.  A kernel regression is also added as a method to smooth marginal tax rates over the income distribution.  A bandwidth around 10000-15000 works well here.

The candidate comparison notebook is updated to include these new plots and mtr smoothing. 