### PR TITLE
Allow non-constant elasticity of taxable income

### DIFF
--- a/examples/ComparingCandidatePlatforms.ipynb
+++ b/examples/ComparingCandidatePlatforms.ipynb
@@ -110,7 +110,7 @@
     "    mtr_wrt=\"e00200p\",\n",
     "    income_measure=income_measure,\n",
     "    weight_var=\"s006\",\n",
-    "    inc_elast=0.25,\n",
+    "    eti=0.25,\n",
     ")"
    ]
   },

--- a/examples/example.py
+++ b/examples/example.py
@@ -21,7 +21,7 @@ iot2 = iot_comparison(
     baseline_policies=[None, None],
     labels=["2017 Law", "Biden 2020"],
     years=[2017, 2020],
-    inc_elast=0.2,
+    eti=0.2,
 )
 
 # %%

--- a/iot/generate_data.py
+++ b/iot/generate_data.py
@@ -63,9 +63,7 @@ def gen_microdata(
                 baseline = tc.Policy.read_json_reform(s)
             else:
                 baseline = s
-            pol1.implement_reform(
-                baseline, print_warnings=False, raise_errors=False
-            )
+            pol1.implement_reform(baseline, print_warnings=False, raise_errors=False)
     else:
         pol1 = tc.Policy()
 

--- a/iot/generate_data.py
+++ b/iot/generate_data.py
@@ -63,7 +63,9 @@ def gen_microdata(
                 baseline = tc.Policy.read_json_reform(s)
             else:
                 baseline = s
-            pol1.implement_reform(baseline, print_warnings=False, raise_errors=False)
+            pol1.implement_reform(
+                baseline, print_warnings=False, raise_errors=False
+            )
     else:
         pol1 = tc.Policy()
 

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -130,7 +130,9 @@ class IOT:
                     for each income bin
         """
         bins = 1000  # number of equal-width bins
-        data.loc[:, ["z_bin"]] = pd.cut(data[income_measure], bins, include_lowest=True)
+        data.loc[:, ["z_bin"]] = pd.cut(
+            data[income_measure], bins, include_lowest=True
+        )
         binned_data = pd.DataFrame(
             data[["mtr", income_measure, "z_bin", weight_var]]
             .groupby(["z_bin"])
@@ -189,11 +191,14 @@ class IOT:
         # drop zero income observations
         data = data[data[income_measure] > 0]
         if dist_type == "log_normal":
-            mu = (np.log(data[income_measure]) * data[weight_var]).sum() / data[
-                weight_var
-            ].sum()
+            mu = (
+                np.log(data[income_measure]) * data[weight_var]
+            ).sum() / data[weight_var].sum()
             sigmasq = (
-                (((np.log(data[income_measure]) - mu) ** 2) * data[weight_var]).values
+                (
+                    ((np.log(data[income_measure]) - mu) ** 2)
+                    * data[weight_var]
+                ).values
                 / data[weight_var].sum()
             ).sum()
             # F = st.lognorm.cdf(z_line, s=(sigmasq) ** 0.5, scale=np.exp(mu))
@@ -204,7 +209,10 @@ class IOT:
             # analytical derivative of lognormal
             sigma = np.sqrt(sigmasq)
             F = (1 / 2) * (
-                1 + scipy.special.erf((np.log(z_line) - mu) / (np.sqrt(2) * sigma))
+                1
+                + scipy.special.erf(
+                    (np.log(z_line) - mu) / (np.sqrt(2) * sigma)
+                )
             )
             f = (
                 (1 / (sigma * np.sqrt(2 * np.pi)))
@@ -261,7 +269,9 @@ class IOT:
         )
         # use Lockwood and Weinzierl formula, which should be equivalent but using numerical differentiation
         bracket_term = (
-            1 - self.F - (self.mtr / (1 - self.mtr)) * self.eti * self.z * self.f
+            1
+            - self.F
+            - (self.mtr / (1 - self.mtr)) * self.eti * self.z * self.f
         )
         # d_dz_bracket = np.gradient(bracket_term, edge_order=2)
         d_dz_bracket = np.diff(bracket_term) / np.diff(self.z)

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -305,9 +305,8 @@ def find_eti(iot1, iot2, g_z_type="g_z"):
     else:
         g_z = iot1.g_z_numerical
     # The equation below is a simplication of the above to make the integration easier
-    eti_beliefs_lw = (
-        ((1 - iot2.mtr) / (iot2.z * iot2.f * iot2.mtr)) *
-        (1 - iot2.F - (g_z.sum() - np.cumsum(g_z)))
+    eti_beliefs_lw = ((1 - iot2.mtr) / (iot2.z * iot2.f * iot2.mtr)) * (
+        1 - iot2.F - (g_z.sum() - np.cumsum(g_z))
     )
     # derivation from JJZ analytical solution that doesn't involved integration
     eti_beliefs_jjz = (g_z - 1) / (

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -287,7 +287,7 @@ def find_eti(iot1, iot2, g_z_type="g_z"):
     social welfare function inferred from the policies of iot1.
 
     .. math::
-            \varepilon_{z} = \frac{(1-T'(z))}{T'(z)}\frac{(1-F(z))}{zf(z)}\int_{z}^{\infty}\frac{1-g_{\tilde{z}}{1-F(y)}dF(\tilde{z})
+            \varepsilon_{z} = \frac{(1-T'(z))}{T'(z)}\frac{(1-F(z))}{zf(z)}\int_{z}^{\infty}\frac{1-g_{\tilde{z}}{1-F(y)}dF(\tilde{z})
 
     Args:
         iot1 (IOT): IOT class instance representing baseline policy

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -19,7 +19,7 @@ class IOT:
             weight_var, mtr
         income_measure (str): name of income measure from data to use
         weight_var (str): name of weight measure from data to use
-        inc_elast (scalar): compensated elasticity of taxable income
+        eti (scalar): compensated elasticity of taxable income
             w.r.t. the marginal tax rate
         bandwidth (scalar): size of income bins in units of income
         lower_bound (scalar): minimum income to consider
@@ -38,7 +38,7 @@ class IOT:
         data,
         income_measure="e00200",
         weight_var="s006",
-        inc_elast=0.25,
+        eti=0.25,
         bandwidth=1000,
         lower_bound=0,
         upper_bound=500000,
@@ -54,7 +54,7 @@ class IOT:
         #     (data[income_measure] >= lower_bound)
         #     & (data[income_measure] <= upper_bound)
         # ]
-        self.inc_elast = inc_elast
+        self.eti = eti
         self.z, self.F, self.f, self.f_prime = self.compute_income_dist(
             data, income_measure, weight_var, dist_type, kde_bw
         )
@@ -243,9 +243,9 @@ class IOT:
         """
         g_z = (
             1
-            + ((self.theta_z * self.inc_elast * self.mtr) / (1 - self.mtr))
+            + ((self.theta_z * self.eti * self.mtr) / (1 - self.mtr))
             + (
-                (self.inc_elast * self.z * self.mtr_prime)
+                (self.eti * self.z * self.mtr_prime)
                 / (1 - self.mtr) ** 2
             )
         )
@@ -253,7 +253,7 @@ class IOT:
         bracket_term = (
             1
             - self.F
-            - (self.mtr / (1 - self.mtr)) * self.inc_elast * self.z * self.f
+            - (self.mtr / (1 - self.mtr)) * self.eti * self.z * self.f
         )
         # d_dz_bracket = np.gradient(bracket_term, edge_order=2)
         d_dz_bracket = np.diff(bracket_term) / np.diff(self.z)

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -130,9 +130,7 @@ class IOT:
                     for each income bin
         """
         bins = 1000  # number of equal-width bins
-        data.loc[:, ["z_bin"]] = pd.cut(
-            data[income_measure], bins, include_lowest=True
-        )
+        data.loc[:, ["z_bin"]] = pd.cut(data[income_measure], bins, include_lowest=True)
         binned_data = pd.DataFrame(
             data[["mtr", income_measure, "z_bin", weight_var]]
             .groupby(["z_bin"])
@@ -191,14 +189,11 @@ class IOT:
         # drop zero income observations
         data = data[data[income_measure] > 0]
         if dist_type == "log_normal":
-            mu = (
-                np.log(data[income_measure]) * data[weight_var]
-            ).sum() / data[weight_var].sum()
+            mu = (np.log(data[income_measure]) * data[weight_var]).sum() / data[
+                weight_var
+            ].sum()
             sigmasq = (
-                (
-                    ((np.log(data[income_measure]) - mu) ** 2)
-                    * data[weight_var]
-                ).values
+                (((np.log(data[income_measure]) - mu) ** 2) * data[weight_var]).values
                 / data[weight_var].sum()
             ).sum()
             # F = st.lognorm.cdf(z_line, s=(sigmasq) ** 0.5, scale=np.exp(mu))
@@ -209,10 +204,7 @@ class IOT:
             # analytical derivative of lognormal
             sigma = np.sqrt(sigmasq)
             F = (1 / 2) * (
-                1
-                + scipy.special.erf(
-                    (np.log(z_line) - mu) / (np.sqrt(2) * sigma)
-                )
+                1 + scipy.special.erf((np.log(z_line) - mu) / (np.sqrt(2) * sigma))
             )
             f = (
                 (1 / (sigma * np.sqrt(2 * np.pi)))
@@ -269,9 +261,7 @@ class IOT:
         )
         # use Lockwood and Weinzierl formula, which should be equivalent but using numerical differentiation
         bracket_term = (
-            1
-            - self.F
-            - (self.mtr / (1 - self.mtr)) * self.eti * self.z * self.f
+            1 - self.F - (self.mtr / (1 - self.mtr)) * self.eti * self.z * self.f
         )
         # d_dz_bracket = np.gradient(bracket_term, edge_order=2)
         d_dz_bracket = np.diff(bracket_term) / np.diff(self.z)

--- a/iot/inverse_optimal_tax.py
+++ b/iot/inverse_optimal_tax.py
@@ -5,6 +5,7 @@ import scipy
 from statsmodels.nonparametric.kernel_regression import KernelReg
 from scipy.interpolate import UnivariateSpline
 
+
 class IOT:
     """
     Constructor for the IOT class.
@@ -68,7 +69,7 @@ class IOT:
             # assume that eti can't go beyond 1 (or the max of the eti_values provided)
             eti_spl = UnivariateSpline(
                 eti["knot_points"], eti["eti_values"], k=1, s=0
-                )
+            )
             self.eti = eti_spl(self.z)
         # compute marginal tax rate schedule
         self.mtr, self.mtr_prime = self.compute_mtr_dist(
@@ -259,10 +260,7 @@ class IOT:
         g_z = (
             1
             + ((self.theta_z * self.eti * self.mtr) / (1 - self.mtr))
-            + (
-                (self.eti * self.z * self.mtr_prime)
-                / (1 - self.mtr) ** 2
-            )
+            + ((self.eti * self.z * self.mtr_prime) / (1 - self.mtr) ** 2)
         )
         # use Lockwood and Weinzierl formula, which should be equivalent but using numerical differentiation
         bracket_term = (

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -30,7 +30,7 @@ class iot_comparison:
         mtr_wtr (str): name of income source to compute MTR on
         income_measure (str): name of income measure from data to use
         weight_var (str): name of weight measure from data to use
-        inc_elast (scalar): compensated elasticity of taxable income
+        eti (scalar): compensated elasticity of taxable income
             w.r.t. the marginal tax rate
         bandwidth (scalar): size of income bins in units of income
         lower_bound (scalar): minimum income to consider
@@ -55,7 +55,7 @@ class iot_comparison:
         mtr_wrt="e00200p",
         income_measure="e00200",
         weight_var="s006",
-        inc_elast=0.25,
+        eti=0.25,
         bandwidth=1000,
         lower_bound=0,
         upper_bound=500000,
@@ -103,7 +103,7 @@ class iot_comparison:
                     j,
                     income_measure=income_measure,
                     weight_var=weight_var,
-                    inc_elast=inc_elast,
+                    eti=eti,
                     bandwidth=bandwidth,
                     lower_bound=lower_bound,
                     upper_bound=upper_bound,
@@ -208,15 +208,15 @@ class iot_comparison:
         # g1 with mtr_prime = 0
         g1 = (
             0
-            + ((df.theta_z * self.iot[k].inc_elast * df.mtr) / (1 - df.mtr))
-            + ((self.iot[k].inc_elast * df.z * 0) / (1 - df.mtr) ** 2)
+            + ((df.theta_z * self.iot[k].eti * df.mtr) / (1 - df.mtr))
+            + ((self.iot[k].eti * df.z * 0) / (1 - df.mtr) ** 2)
         )
         # g2 with theta_z = 0
         g2 = (
             0
-            + ((0 * self.iot[k].inc_elast * df.mtr) / (1 - df.mtr))
+            + ((0 * self.iot[k].eti * df.mtr) / (1 - df.mtr))
             + (
-                (self.iot[k].inc_elast * df.z * df.mtr_prime)
+                (self.iot[k].eti * df.z * df.mtr_prime)
                 / (1 - df.mtr) ** 2
             )
         )

--- a/iot/iot_user.py
+++ b/iot/iot_user.py
@@ -215,10 +215,7 @@ class iot_comparison:
         g2 = (
             0
             + ((0 * self.iot[k].eti * df.mtr) / (1 - df.mtr))
-            + (
-                (self.iot[k].eti * df.z * df.mtr_prime)
-                / (1 - df.mtr) ** 2
-            )
+            + ((self.iot[k].eti * df.z * df.mtr_prime) / (1 - df.mtr) ** 2)
         )
         plot_df = pd.DataFrame(
             {

--- a/iot/tests/test_inverse_optimal_tax.py
+++ b/iot/tests/test_inverse_optimal_tax.py
@@ -157,7 +157,7 @@ def test_IOT_df():
 # )
 # iot2 = copy.deepcopy(iot1)
 # iot2.theta_z = np.array([1.7, 2.4, 99.0, 1.5, 1.5, 1.5])
-# iot2.inc_elast = np.array([0.3, 0.1, 0.0, 0.4, 0.4, 0.4])
+# iot2.eti = np.array([0.3, 0.1, 0.0, 0.4, 0.4, 0.4])
 # iot2.mtr = np.array([0.25, 0.2, 0.25, 0.25, 0.25, 0.0])
 # iot2.z = np.array([5000.0, 5000.0, 5000.0, 5000.0, 300.0, 300.0])
 # iot2.mtr_prime = np.array([0.03, 0.03, 0.03, 0.0, 0.0, 0.0])
@@ -285,7 +285,7 @@ def test_IOT_df():
 #         weight_var=weight_var,
 #         dist_type=dist_type,
 #         mtr_smoother=mtr_smoother,
-#         inc_elast=elasticity,
+#         eti=elasticity,
 #     )
 #     if sim_dist_type == "exponential":
 #         g_z_test = iot_test.g_z


### PR DESCRIPTION
This PR adds the ability for users to enter an elasticity of taxable income that varies over the earned income distribution, which would resolve Issue #21.  The functionality allows the user to enter a value of `eti` that is either a scalar (i.e., constant over income) or a dictionary with keys `knot_points` and `etc_values`, which each contain corresponding lists of income values and the ETI at those values.  E.g., using the estimate of the ETI over the income distribution from [Gruber and Saez (2002)](http://piketty.pse.ens.fr/files/GruberSaez2002.pdf), this would look like:

```python
eti_dict = {
    "eti_values": [0.18, 0.106, 0.567, 1.0],
    "knot_points": [30000, 75000, 250000, 10000000]
}
```

Where the last value is provided to help find just a gradual increase in the ETI after $250,000.  Using a linear spline, the results look like:
![linear_spline](https://github.com/PSLmodels/InverseOptimalTax/assets/10715924/918108e0-2bdd-47f9-b373-ac77e1626739)

The sharp changes in the ETI in this interpolated function are probably not realistic and introduce odd kinds in the implied social welfare weights.  

However, with so few datapoints, a cubic spline has its own problems (going off to values that are unrealistically high):
![cubic_spline](https://github.com/PSLmodels/InverseOptimalTax/assets/10715924/40cd20ff-9a73-4537-b2d6-973d4ff19edd)

I believe the solution is to find more data points on the ETI on different parts of the income distribution that can be used to inform a cubic spline.  This should allow for some smoothness in the ETI spline, but without a steep slope in some values beyond those in the literature.

cc @john-p-ryan 



