### PR TITLE
Codecov only on `main` branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,8 +1,6 @@
 name: Build and test [Python 3.9, 3.10, 3.11]
 
 on: [push, pull_request]
-  branches:
-    - main
 
 jobs:
   build:
@@ -37,6 +35,7 @@ jobs:
         run: |
           pytest -m 'not full_run and not regression' --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
+        if: contains(github.ref, 'main')
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,8 @@
 name: Build and test [Python 3.9, 3.10, 3.11]
 
 on: [push, pull_request]
+  branches:
+    - main
 
 jobs:
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pytest -m 'not full_run and not regression' --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: contains(github.ref, 'main')
+        if: contains(github.repository, 'PSLmodels/InverseOptimalTax')
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR updates the GH Actions to only run `codecov` on the main branch.  This will help avoid test failures on forked repos which don't have the proper credentials to upload the codecov token.